### PR TITLE
[draft] Spoof login

### DIFF
--- a/resources/views/spoof-settings.php
+++ b/resources/views/spoof-settings.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Settings view.
+ *
+ * @package OWC_Signicat_OpenID
+ *
+ * @author  Yard | Digital Agency
+ *
+ * @since   0.0.1
+ */
+
+declare (strict_types=1);
+
+namespace OWCSignicatOpenID;
+
+?>
+
+<div class="wrap">
+	<h1><?php esc_html_e('Signicat Simulator', 'owc-signicat-openid'); ?></h1>
+
+    <p>Nog geen Signicat aansluiting gerealiseerd? Worry no more! Met de Signicat Simulator 2000™ kun je net doen alsof je ingelogd bent op DigiD!</p>
+
+	<form method="post" action="options.php">
+		<?php settings_fields('owc_signicat_simulator_settings_group'); ?>
+		<?php do_settings_sections('owc_signicat_simulator_settings_group'); ?>
+		<table class="form-table">
+            <tr>
+				<th scope="row">
+					<label for="owc_signicat_simulator_enable_simulator_settings">
+						<?php esc_html_e('Enable simulator', 'owc-signicat-openid'); ?>
+					</label>
+				</th>
+				<td>
+					<input type='checkbox' name='owc_signicat_simulator_enable_simulator_settings' <?php checked($enable_simulator, 1); ?> value='1'>
+				</td>
+			</tr>
+            
+            <tr>
+				<th scope="row">
+					<label for="owc_signicat_simulator_bsn_settings">
+						<?php esc_html_e('BSN-nummer', 'owc-signicat-openid'); ?>
+					</label>
+				</th>
+				<td>
+					<input type="number" min="0" name="owc_signicat_simulator_bsn_settings" id="owc_signicat_simulator_bsn_settings" value="<?php echo esc_attr($bsn); ?>">
+				</td>
+			</tr>
+
+            <tr>
+				<th scope="row">
+					<label for="owc_signicat_simulator_levelOfAssurance_settings">
+						<?php esc_html_e('Zekerheidsniveau', 'owc-signicat-openid'); ?>
+					</label>
+				</th>
+				<td>
+					<input type="text" name="owc_signicat_simulator_levelOfAssurance_settings" id="owc_signicat_simulator_levelOfAssurance_settings" value="<?php echo esc_attr($levelOfAssurance); ?>">
+				</td>
+			</tr>
+		</table>
+		<?php submit_button(); ?>
+	</form>
+</div>

--- a/src/Bootstrap.php
+++ b/src/Bootstrap.php
@@ -15,6 +15,7 @@ namespace OWCSignicatOpenID;
 use Exception;
 use OWCSignicatOpenID\Interfaces\Providers\AppServiceProviderInterface;
 use OWCSignicatOpenID\Interfaces\Providers\SettingsServiceProviderInterface;
+use OWCSignicatOpenID\Providers\SpoofServiceProvider;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -84,6 +85,7 @@ final class Bootstrap
         $providers = [
             SettingsServiceProviderInterface::class,
             AppServiceProviderInterface::class,
+            SpoofServiceProvider::class,
         ];
         $registeredProviders = [];
         foreach ($providers as $provider) {

--- a/src/Providers/AppServiceProvider.php
+++ b/src/Providers/AppServiceProvider.php
@@ -25,7 +25,6 @@ use OWCSignicatOpenID\Interfaces\Services\GravityFormsServiceInterface;
 use OWCSignicatOpenID\Interfaces\Services\LifeCycleServiceInterface;
 use OWCSignicatOpenID\Interfaces\Services\ModalServiceInterface;
 use OWCSignicatOpenID\Interfaces\Services\RouteServiceInterface;
-use OWCSignicatOpenID\Services\SpoofService;
 
 /**
  * App service provider (registers general plugins functionality).
@@ -39,8 +38,7 @@ class AppServiceProvider extends ServiceProvider implements AppServiceProviderIn
         BlockServiceInterface $blockService,
         RouteServiceInterface $routeService,
         GravityFormsServiceInterface $gravityFormsService,
-        ModalServiceInterface $modalService,
-        SpoofService $spoofService
+        ModalServiceInterface $modalService
     ) {
         $this->services = [
             'life_cycle' => $lifeCycleService,
@@ -48,7 +46,6 @@ class AppServiceProvider extends ServiceProvider implements AppServiceProviderIn
             'route'      => $routeService,
             'gravity_forms' => $gravityFormsService,
             'modal'     => $modalService,
-            'spoof'     => $spoofService,
         ];
 
         $this->register_hooks();

--- a/src/Providers/SpoofServiceProvider.php
+++ b/src/Providers/SpoofServiceProvider.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace OWCSignicatOpenID\Providers;
+
+use OWCSignicatOpenID\Services\SpoofService;
+use OWCSignicatOpenID\Services\SpoofSettingsService;
+
+class SpoofServiceProvider extends ServiceProvider
+{
+    public function __construct(
+        SpoofSettingsService $settingsService,
+        SpoofService $spoofService
+    ) {
+        $this->services = [
+            'settings'   => $settingsService,
+            'spoof' => $spoofService
+        ];
+    }
+}

--- a/src/Services/SpoofSettingsService.php
+++ b/src/Services/SpoofSettingsService.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OWCSignicatOpenID\Services;
+
+use OWCSignicatOpenID\Interfaces\Services\SettingsServiceInterface;
+use OWCSignicatOpenID\Interfaces\Services\ViewServiceInterface;
+
+class SpoofSettingsService extends Service implements SettingsServiceInterface
+{
+    protected ViewServiceInterface $view_service;
+
+    protected array $settings = [
+        'enable_simulator', 'bsn', 'levelOfAssurance'
+    ];
+
+    public function __construct(ViewServiceInterface $view_service)
+    {
+        $this->view_service = $view_service;
+    }
+
+    public function register()
+    {
+        add_action('admin_init', [ $this, 'register_settings' ]);
+        add_action('admin_menu', [ $this, 'add_settings_page' ]);
+    }
+
+    public function add_settings_page(): void
+    {
+        add_options_page(
+            'owc-signicat-simulator',
+            esc_html__('Signicat Simulator', 'owc-signicat-openid'),
+            'manage_options',
+            'owc-signicat-simulator',
+            [ $this, 'render_settings_page' ]
+        );
+    }
+
+    public function register_settings(): void
+    {
+        foreach ($this->settings as $setting) {
+            register_setting('owc_signicat_simulator_settings_group', "owc_signicat_simulator_{$setting}_settings");
+        }
+    }
+
+    public function render_settings_page(): void
+    {
+        foreach ($this->settings as $setting) {
+            $data[$setting] = $this->getSetting($setting);
+        }
+        echo $this->view_service->render('spoof-settings', $data);
+    }
+
+    public function getSetting(string $setting)
+    {
+        return get_option("owc_signicat_simulator_{$setting}_settings");
+    }
+}

--- a/src/UserData/SpoofDigiDUserData.php
+++ b/src/UserData/SpoofDigiDUserData.php
@@ -6,11 +6,4 @@ namespace OWCSignicatOpenID\UserData;
 
 class SpoofDigiDUserData extends DigiDUserData
 {
-    public function getBsn(): string
-    {
-        $this->bsn = '359981744';
-        $this->levelOfAssurance = 'over 9000';
-
-        return '359981744';
-    }
 }


### PR DESCRIPTION
Ik heb een aanzet gemaakt hoe een gemeente kan testen met bijv. MijnZaken zonder eerst een Signicat verbinding te realiseren. De hoofdvraag is nu: is dit werkbaar voor jullie?

Er wordt een nieuw instellingen submenu toegevoegd (Signicat Simulator). Zodra je deze activeert, is iedereen direct 'ingelogd'. Hier kunnen natuurlijk nog checks aan toegevoegd worden, bijvoorbeeld dat dit enkel gedrag is bij admins o.i.d.

Instellingen scherm:
<img width="1098" alt="Scherm­afbeelding 2025-04-14 om 19 31 08" src="https://github.com/user-attachments/assets/6dbbe1f4-7029-44b6-b5da-a0e2cdb586d5" />

Als de simulator geactiveerd is, dan kun je onderstaande resultaat verwachten:

```php
    var_dump(
        \OWC\IdpUserData\DigiDSession::isLoggedIn(),
        \OWC\IdpUserData\DigiDSession::getUserData(),
        \OWC\IdpUserData\DigiDSession::getUserData()->getBsn()
    );
```

<img width="830" alt="Scherm­afbeelding 2025-04-14 om 19 32 27" src="https://github.com/user-attachments/assets/0cd95dc1-02c0-4a5e-be08-360d0dfb5171" />

