### PR TITLE
(fix): return value of GravityFormsService::decrypt()

### DIFF
--- a/src/Services/GravityFormsService.php
+++ b/src/Services/GravityFormsService.php
@@ -49,7 +49,7 @@ class GravityFormsService extends Service implements GravityFormsServiceInterfac
 		}
 
 		// TODO: optie/filter om decryption te onderdrukken
-		return \GFCommon::openssl_decrypt( $value );
+		return \GFCommon::openssl_decrypt( $value ) ?: $value;
 	}
 
 	public function encrypt($value, $entry, $field, $form, $input_id )


### PR DESCRIPTION
Fatal error: Uncaught TypeError: Return value of OWCSignicatOpenID\Services\GravityFormsService::decrypt() must be of the type string, bool returned in /htdocs/wp-content/plugins/owc-signicat-openid/src/Services/GravityFormsService.php:52