### PR TITLE
fix: Odan PHP session constructor params

### DIFF
--- a/config/php-di.php
+++ b/config/php-di.php
@@ -109,9 +109,9 @@ return array(
 		->build(),
 	AuthorizationService::class             => fn (): AuthorizationService => ( new AuthorizationServiceBuilder() )->build(),
 	'session_options'                       => array(
-		'name'            => 'OWC_Signicat_OpenID',
-		'cookie_secure'   => true,
-		'cookie_httponly' => true,
+		'name'     => 'OWC_Signicat_OpenID',
+		'secure'   => true,
+		'httponly' => true,
 	),
 	SessionInterface::class                 => function (ContainerInterface $container ): PhpSession {
 		$session = new PhpSession($container->get( 'session_options' ) );

--- a/src/IdentityProvider.php
+++ b/src/IdentityProvider.php
@@ -28,7 +28,7 @@ class IdentityProvider implements JsonSerializable
 		$this->scope = sprintf( 'idp_scoping:%s', $this->slug );
 	}
 
-	public function jsonSerialize()
+	public function jsonSerialize(): mixed
 	{
 		return array(
 			'slug' => $this->slug,


### PR DESCRIPTION
Example of the Odan PHP session class:

```
/**
 * A PHP Session handler adapter.
 */
final class PhpSession implements SessionInterface, SessionManagerInterface
{
    /**
     * @var array<string, mixed>
     */
    private array $storage;

    private FlashInterface $flash;

    /**
     * @var array<string, mixed>
     */
    private array $options = [
        'id' => null,
        'name' => 'app',
        'lifetime' => 7200,
        'path' => null,
        'domain' => null,
        'secure' => false,
        'httponly' => true,
        // public, private_no_expire, private, nocache
        // Setting the cache limiter to '' will turn off automatic sending of cache headers entirely.
        'cache_limiter' => 'nocache',
    ];
```